### PR TITLE
make application config cacheable & cache it in production

### DIFF
--- a/bin/git-hooks/pre-commit
+++ b/bin/git-hooks/pre-commit
@@ -95,14 +95,8 @@ fi
 
 if [ $GIT_STASH -eq 1 ]
 then
-    # make a commit of all staged changes without running the hooks!
-    git commit --quiet --no-verify --message='pre-commit hook commit --DO NOT PUSH--'
-
-    # now make the stash
-    git stash save --include-untracked --quiet 'pre-commit hook stash'
-
-    # undo the commit, but keep staged stuff staged
-    git reset --quiet --soft HEAD^
+    # make the stash
+    git stash save --keep-index --include-untracked --quiet 'pre-commit hook stash'
 
     log_info 'Untracked changes have been stashed'
 fi

--- a/config/application.config.php
+++ b/config/application.config.php
@@ -69,5 +69,24 @@ return array(
             './module',
             './vendor',
         ),
+
+        // Whether or not to enable a configuration cache.
+        // If enabled, the merged configuration will be cached and used in
+        // subsequent requests.
+        'config_cache_enabled' => ('production' == getenv('APPLICATION_ENV')),
+
+        // The key used to create the configuration cache file name.
+        'config_cache_key' => 'zf2.configuration',
+
+        // Whether or not to enable a module class map cache.
+        // If enabled, creates a module class map cache which will be used
+        // by in future requests, to reduce the autoloading process.
+        'module_map_cache_enabled' => ('production' == getenv('APPLICATION_ENV')),
+
+        // The key used to create the class map cache file name.
+        'module_map_cache_key' => 'zf2.classmap',
+
+        // The path in which to cache merged configuration.
+        'cache_dir' => 'data/cache',
     ),
 );

--- a/config/autoload/database.global.php
+++ b/config/autoload/database.global.php
@@ -27,27 +27,10 @@ $databaseConfig = include __DIR__ . '/../database.config.php';
 return array(
     'service_manager' => array(
         'factories' => array(
-            'doctrine.cache.orm_default' => function () {
-                if ('production' == getenv('APPLICATION_ENV')) {
-                    if (!extension_loaded('memcached')) {
-                        throw new \RuntimeException('Litus requires the memcached extension to be loaded');
-                    }
-
-                    $cache = new \Doctrine\Common\Cache\MemcachedCache();
-                    $cache->setNamespace(getenv('ORGANIZATION') . '_LITUS');
-                    $memcached = new \Memcached();
-
-                    if (!$memcached->addServer('localhost', 11211)) {
-                        throw now \RuntimeException('Failed to connect to the memcached server');
-                    }
-
-                    $cache->setMemcached($memcached);
-                } else {
-                    $cache = new \Doctrine\Common\Cache\ArrayCache();
-                }
-
-                return $cache;
-            },
+            'doctrine.cache.orm_default' =>
+                ('production' == getenv('APPLICATION_ENV'))
+                ? 'CommonBundle\Component\ApplicationConfig\DatabaseCache\Memcached'
+                : 'CommonBundle\Component\ApplicationConfig\DatabaseCache\Memory',
         ),
     ),
     'doctrine' => array(

--- a/module/CommonBundle/Component/ApplicationConfig/Cache/Memcached.php
+++ b/module/CommonBundle/Component/ApplicationConfig/Cache/Memcached.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Litus is a project by a group of students from the KU Leuven. The goal is to create
+ * various applications to support the IT needs of student unions.
+ *
+ * @author Niels Avonds <niels.avonds@litus.cc>
+ * @author Karsten Daemen <karsten.daemen@litus.cc>
+ * @author Koen Certyn <koen.certyn@litus.cc>
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ * @author Dario Incalza <dario.incalza@litus.cc>
+ * @author Pieter Maene <pieter.maene@litus.cc>
+ * @author Kristof Mariën <kristof.marien@litus.cc>
+ * @author Lars Vierbergen <lars.vierbergen@litus.cc>
+ * @author Daan Wendelen <daan.wendelen@litus.cc>
+ *
+ * @license http://litus.cc/LICENSE
+ */
+
+namespace CommonBundle\Component\ApplicationConfig\Cache;
+
+use RuntimeException,
+    Zend\Cache\StorageFactory,
+    Zend\ServiceManager\ServiceLocatorInterface;
+
+class Memcached implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        if (!extension_loaded('memcached')) {
+            throw new RuntimeException('Litus requires the memcached extension to be loaded');
+        }
+
+        return StorageFactory::factory(
+            array(
+                'adapter' => array(
+                    'name' => 'memcached',
+                    'options' => array(
+                        'ttl' => 0,
+                        'namespace' => getenv('ORGANIZATION') . '_LITUS',
+                        'servers' => array(
+                            array('localhost', 11211),
+                        ),
+                    ),
+                ),
+            )
+        );
+    }
+}

--- a/module/CommonBundle/Component/ApplicationConfig/Cache/Memory.php
+++ b/module/CommonBundle/Component/ApplicationConfig/Cache/Memory.php
@@ -16,13 +16,24 @@
  * @license http://litus.cc/LICENSE
  */
 
-return array(
-    'service_manager' => array(
-        'factories' => array(
-            'cache' =>
-                ('production' == getenv('APPLICATION_ENV'))
-                ? 'CommonBundle\Component\ApplicationConfig\Cache\Memcached'
-                : 'CommonBundle\Component\ApplicationConfig\Cache\Memory',
-        ),
-    ),
-);
+namespace CommonBundle\Component\ApplicationConfig\Cache;
+
+use Zend\Cache\StorageFactory,
+    Zend\ServiceManager\ServiceLocatorInterface;
+
+class Memory implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        return StorageFactory::factory(
+            array(
+                'adapter' => array(
+                    'name' => 'memory',
+                    'options' => array(
+                        'ttl' => 0,
+                    ),
+                ),
+            )
+        );
+    }
+}

--- a/module/CommonBundle/Component/ApplicationConfig/DatabaseCache/Memcached.php
+++ b/module/CommonBundle/Component/ApplicationConfig/DatabaseCache/Memcached.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Litus is a project by a group of students from the KU Leuven. The goal is to create
+ * various applications to support the IT needs of student unions.
+ *
+ * @author Niels Avonds <niels.avonds@litus.cc>
+ * @author Karsten Daemen <karsten.daemen@litus.cc>
+ * @author Koen Certyn <koen.certyn@litus.cc>
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ * @author Dario Incalza <dario.incalza@litus.cc>
+ * @author Pieter Maene <pieter.maene@litus.cc>
+ * @author Kristof Mariën <kristof.marien@litus.cc>
+ * @author Lars Vierbergen <lars.vierbergen@litus.cc>
+ * @author Daan Wendelen <daan.wendelen@litus.cc>
+ *
+ * @license http://litus.cc/LICENSE
+ */
+
+namespace CommonBundle\Component\ApplicationConfig\DatabaseCache;
+
+use Doctrine\Common\Cache\MemcachedCache,
+    Memcached as MemcachedObject,
+    RuntimeException,
+    Zend\ServiceManager\ServiceLocatorInterface;
+
+class Memcached implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        if (!extension_loaded('memcached')) {
+            throw new RuntimeException('Litus requires the memcached extension to be loaded');
+        }
+
+        $cache = new MemcachedCache();
+        $cache->setNamespace(getenv('ORGANIZATION') . '_LITUS');
+        $memcached = new MemcachedObject();
+
+        if (!$memcached->addServer('localhost', 11211)) {
+            throw new RuntimeException('Failed to connect to the memcached server');
+        }
+
+        $cache->setMemcached($memcached);
+
+        return $cache;
+    }
+}

--- a/module/CommonBundle/Component/ApplicationConfig/DatabaseCache/Memory.php
+++ b/module/CommonBundle/Component/ApplicationConfig/DatabaseCache/Memory.php
@@ -16,13 +16,15 @@
  * @license http://litus.cc/LICENSE
  */
 
-return array(
-    'service_manager' => array(
-        'factories' => array(
-            'cache' =>
-                ('production' == getenv('APPLICATION_ENV'))
-                ? 'CommonBundle\Component\ApplicationConfig\Cache\Memcached'
-                : 'CommonBundle\Component\ApplicationConfig\Cache\Memory',
-        ),
-    ),
-);
+namespace CommonBundle\Component\ApplicationConfig\DatabaseCache;
+
+use Doctrine\Common\Cache\ArrayCache,
+    Zend\ServiceManager\ServiceLocatorInterface;
+
+class Memory implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        return new ArrayCache();
+    }
+}

--- a/module/CommonBundle/Component/Authentication/Factory/Action/Doctrine.php
+++ b/module/CommonBundle/Component/Authentication/Factory/Action/Doctrine.php
@@ -16,13 +16,23 @@
  * @license http://litus.cc/LICENSE
  */
 
-return array(
-    'service_manager' => array(
-        'factories' => array(
-            'cache' =>
-                ('production' == getenv('APPLICATION_ENV'))
-                ? 'CommonBundle\Component\ApplicationConfig\Cache\Memcached'
-                : 'CommonBundle\Component\ApplicationConfig\Cache\Memory',
-        ),
-    ),
-);
+namespace CommonBundle\Component\Authentication\Factory\Action;
+
+use CommonBundle\Component\Authentication\Action\Doctrine as DoctrineAction,
+    Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Factory to create a Doctrine Adapter.
+ *
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ */
+class Doctrine implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        return new DoctrineAction(
+            $sl->get('doctrine.entitymanager.orm_default'),
+            $sl->get('mail_transport')
+        );
+    }
+}

--- a/module/CommonBundle/Component/Authentication/Factory/Adapter/Doctrine.php
+++ b/module/CommonBundle/Component/Authentication/Factory/Adapter/Doctrine.php
@@ -16,13 +16,24 @@
  * @license http://litus.cc/LICENSE
  */
 
-return array(
-    'service_manager' => array(
-        'factories' => array(
-            'cache' =>
-                ('production' == getenv('APPLICATION_ENV'))
-                ? 'CommonBundle\Component\ApplicationConfig\Cache\Memcached'
-                : 'CommonBundle\Component\ApplicationConfig\Cache\Memory',
-        ),
-    ),
-);
+namespace CommonBundle\Component\Authentication\Factory\Adapter;
+
+use CommonBundle\Component\Authentication\Adapter\Doctrine\Credential as DoctrineAdapter,
+    Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Factory to create a Doctrine Adapter.
+ *
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ */
+class Doctrine implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        return new DoctrineAdapter(
+            $sl->get('doctrine.entitymanager.orm_default'),
+            'CommonBundle\Entity\User\Person',
+            'username'
+        );
+    }
+}

--- a/module/CommonBundle/Component/Authentication/Factory/Authentication.php
+++ b/module/CommonBundle/Component/Authentication/Factory/Authentication.php
@@ -16,13 +16,23 @@
  * @license http://litus.cc/LICENSE
  */
 
-return array(
-    'service_manager' => array(
-        'factories' => array(
-            'cache' =>
-                ('production' == getenv('APPLICATION_ENV'))
-                ? 'CommonBundle\Component\ApplicationConfig\Cache\Memcached'
-                : 'CommonBundle\Component\ApplicationConfig\Cache\Memory',
-        ),
-    ),
-);
+namespace CommonBundle\Component\Authentication\Factory;
+
+use CommonBundle\Component\Authentication\Authentication as AuthenticationObject,
+    Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Factory to create an authentication object.
+ *
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ */
+class Authentication implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        return new AuthenticationObject(
+            $sl->get('authentication_credentialadapter'),
+            $sl->get('authentication_service')
+        );
+    }
+}

--- a/module/CommonBundle/Component/Authentication/Factory/Service/Doctrine.php
+++ b/module/CommonBundle/Component/Authentication/Factory/Service/Doctrine.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Litus is a project by a group of students from the KU Leuven. The goal is to create
+ * various applications to support the IT needs of student unions.
+ *
+ * @author Niels Avonds <niels.avonds@litus.cc>
+ * @author Karsten Daemen <karsten.daemen@litus.cc>
+ * @author Koen Certyn <koen.certyn@litus.cc>
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ * @author Dario Incalza <dario.incalza@litus.cc>
+ * @author Pieter Maene <pieter.maene@litus.cc>
+ * @author Kristof Mariën <kristof.marien@litus.cc>
+ * @author Lars Vierbergen <lars.vierbergen@litus.cc>
+ * @author Daan Wendelen <daan.wendelen@litus.cc>
+ *
+ * @license http://litus.cc/LICENSE
+ */
+
+namespace CommonBundle\Component\Authentication\Factory\Service;
+
+use CommonBundle\Component\Authentication\Service\Doctrine as DoctrineService,
+    Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Factory to create a Doctrine Service.
+ *
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ */
+class Doctrine implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        return new DoctrineService(
+            $sl->get('doctrine.entitymanager.orm_default'),
+            'CommonBundle\Entity\User\Session',
+            2678400,
+            $sl->get('authentication_sessionstorage'),
+            'Litus_Auth',
+            'Session',
+            $sl->get('authentication_action')
+        );
+    }
+}

--- a/module/CommonBundle/Component/Authentication/Factory/SessionStorage.php
+++ b/module/CommonBundle/Component/Authentication/Factory/SessionStorage.php
@@ -16,13 +16,20 @@
  * @license http://litus.cc/LICENSE
  */
 
-return array(
-    'service_manager' => array(
-        'factories' => array(
-            'cache' =>
-                ('production' == getenv('APPLICATION_ENV'))
-                ? 'CommonBundle\Component\ApplicationConfig\Cache\Memcached'
-                : 'CommonBundle\Component\ApplicationConfig\Cache\Memory',
-        ),
-    ),
-);
+namespace CommonBundle\Component\Authentication\Factory;
+
+use Zend\Authentication\Storage\Session as SessionStorageObject,
+    Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Factory to create a session storage container for authentication.
+ *
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ */
+class SessionStorage implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        return new SessionStorageObject(getenv('ORGANIZATION') . '_Litus_Auth');
+    }
+}

--- a/module/CommonBundle/Component/Form/Factory/AbstractFactory.php
+++ b/module/CommonBundle/Component/Form/Factory/AbstractFactory.php
@@ -16,9 +16,11 @@
  * @license http://litus.cc/LICENSE
  */
 
-namespace CommonBundle\Component\Form;
+namespace CommonBundle\Component\Form\Factory;
 
-use Zend\Filter\FilterChain,
+use CommonBundle\Component\Form\Factory,
+    CommonBundle\Component\Form\FormElementManager,
+    Zend\Filter\FilterChain,
     Zend\ServiceManager\Config,
     Zend\ServiceManager\ServiceLocatorInterface,
     Zend\Validator\ValidatorChain;
@@ -28,25 +30,25 @@ use Zend\Filter\FilterChain,
  *
  * @author Bram Gotink <bram.gotink@litus.cc>
  */
-class FactoryFactory implements \Zend\ServiceManager\FactoryInterface
+class AbstractFactory implements \Zend\ServiceManager\FactoryInterface
 {
     /**
-     * @var bool
+     * @var string
      */
-    private $isAdmin;
+    private $configName;
 
     /**
-     * @param bool
+     * @param string
      */
-    public function __construct($isAdmin)
+    public function __construct($configName)
     {
-        $this->isAdmin = (bool) $isAdmin;
+        $this->configName = $configName;
     }
 
     public function createService(ServiceLocatorInterface $serviceManager)
     {
         $config = $serviceManager->get('Config');
-        $config = $config['litus']['forms'][$this->isAdmin ? 'admin' : 'bootstrap'];
+        $config = $config['litus']['forms'][$this->configName];
         $config = new Config($config);
 
         $factory = new Factory(

--- a/module/CommonBundle/Component/Form/Factory/Admin.php
+++ b/module/CommonBundle/Component/Form/Factory/Admin.php
@@ -16,13 +16,17 @@
  * @license http://litus.cc/LICENSE
  */
 
-return array(
-    'service_manager' => array(
-        'factories' => array(
-            'cache' =>
-                ('production' == getenv('APPLICATION_ENV'))
-                ? 'CommonBundle\Component\ApplicationConfig\Cache\Memcached'
-                : 'CommonBundle\Component\ApplicationConfig\Cache\Memory',
-        ),
-    ),
-);
+namespace CommonBundle\Component\Form\Factory;
+
+/**
+ * A factory to create a FormFactory for admin forms.
+ *
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ */
+class Admin extends AbstractFactory
+{
+    public function __construct()
+    {
+        parent::__construct('admin');
+    }
+}

--- a/module/CommonBundle/Component/Form/Factory/Bootstrap.php
+++ b/module/CommonBundle/Component/Form/Factory/Bootstrap.php
@@ -16,13 +16,17 @@
  * @license http://litus.cc/LICENSE
  */
 
-return array(
-    'service_manager' => array(
-        'factories' => array(
-            'cache' =>
-                ('production' == getenv('APPLICATION_ENV'))
-                ? 'CommonBundle\Component\ApplicationConfig\Cache\Memcached'
-                : 'CommonBundle\Component\ApplicationConfig\Cache\Memory',
-        ),
-    ),
-);
+namespace CommonBundle\Component\Form\Factory;
+
+/**
+ * A factory to create a FormFactory for bootstrap forms.
+ *
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ */
+class Bootstrap extends AbstractFactory
+{
+    public function __construct()
+    {
+        parent::__construct('bootstrap');
+    }
+}

--- a/module/CommonBundle/Component/Module/Factory/SessionStorage.php
+++ b/module/CommonBundle/Component/Module/Factory/SessionStorage.php
@@ -16,13 +16,20 @@
  * @license http://litus.cc/LICENSE
  */
 
-return array(
-    'service_manager' => array(
-        'factories' => array(
-            'cache' =>
-                ('production' == getenv('APPLICATION_ENV'))
-                ? 'CommonBundle\Component\ApplicationConfig\Cache\Memcached'
-                : 'CommonBundle\Component\ApplicationConfig\Cache\Memory',
-        ),
-    ),
-);
+namespace CommonBundle\Component\Module\Factory;
+
+use Zend\ServiceManager\ServiceLocatorInterface,
+    Zend\Session\Container as SessionContainer;
+
+/**
+ * Factory to create a session storage container.
+ *
+ * @author Bram Gotink <bram.gotink@litus.cc>
+ */
+class SessionStorage implements \Zend\ServiceManager\FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        return new SessionContainer(getenv('ORGANIZATION') . '_Litus_Common');
+    }
+}

--- a/module/CommonBundle/Resources/config/module.config.php
+++ b/module/CommonBundle/Resources/config/module.config.php
@@ -30,51 +30,23 @@ return Config::create(
     array(
         'service_manager' => array(
             'factories' => array(
-                'authentication' => function ($serviceManager) {
-                    return new Component\Authentication\Authentication(
-                        $serviceManager->get('authentication_credentialadapter'),
-                        $serviceManager->get('authentication_service')
-                    );
-                },
-                'authentication_doctrinecredentialadapter' => function ($serviceManager) {
-                    return new Component\Authentication\Adapter\Doctrine\Credential(
-                        $serviceManager->get('doctrine.entitymanager.orm_default'),
-                        'CommonBundle\Entity\User\Person',
-                        'username'
-                    );
-                },
-                'authentication_doctrineservice' => function ($serviceManager) {
-                    return new Component\Authentication\Service\Doctrine(
-                        $serviceManager->get('doctrine.entitymanager.orm_default'),
-                        'CommonBundle\Entity\User\Session',
-                        2678400,
-                        $serviceManager->get('authentication_sessionstorage'),
-                        'Litus_Auth',
-                        'Session',
-                        $serviceManager->get('authentication_action')
-                    );
-                },
-                'authentication_doctrineaction' => function ($serviceManager) {
-                    return new Component\Authentication\Action\Doctrine(
-                        $serviceManager->get('doctrine.entitymanager.orm_default'),
-                        $serviceManager->get('mail_transport')
-                    );
-                },
-                'authentication_sessionstorage' => function () {
-                    return new \Zend\Authentication\Storage\Session(getenv('ORGANIZATION') . '_Litus_Auth');
-                },
+                'authentication' => 'CommonBundle\Component\Authentication\Factory\Authentication',
 
-                'common_sessionstorage' => function () {
-                    return new \Zend\Session\Container(getenv('ORGANIZATION') . '_Litus_Common');
-                },
+                'authentication_doctrinecredentialadapter' => 'CommonBundle\Component\Authentication\Factory\Adapter\Doctrine',
+                'authentication_doctrineservice' => 'CommonBundle\Component\Authentication\Factory\Service\Doctrine',
+                'authentication_doctrineaction' => 'CommonBundle\Component\Authentication\Factory\Action\Doctrine',
+
+                'authentication_sessionstorage' => 'CommonBundle\Component\Authentication\Factory\SessionStorage',
+
+                'common_sessionstorage' => 'CommonBundle\Component\Module\Factory\SessionStorage',
 
                 'AsseticBundle\Service' => 'CommonBundle\Component\Assetic\ServiceFactory',
 
                 'doctrine.cli' => 'CommonBundle\Component\Console\ApplicationFactory',
                 'litus.console_router' => 'CommonBundle\Component\Mvc\Router\Console\RouteStackFactory',
 
-                'formfactory.bootstrap' => new Component\Form\FactoryFactory(false),
-                'formfactory.admin'     => new Component\Form\FactoryFactory(true),
+                'formfactory.bootstrap' => 'CommonBundle\Component\Form\Factory\Bootstrap',
+                'formfactory.admin'     => 'CommonBundle\Component\Form\Factory\Admin',
             ),
             'invokables' => array(
                 'mail_transport'     => 'Zend\Mail\Transport\Sendmail',

--- a/module/SyllabusBundle/Component/XMLParser/Study.php
+++ b/module/SyllabusBundle/Component/XMLParser/Study.php
@@ -476,7 +476,7 @@ class Study
 
                 $generalGroups = $this->getGeneralMandatoryGroups($combination['entity']->getPhase(), $moduleGroups);
                 if (!empty($generalGroups)) {
-                   $groups = array_merge($groups, $generalGroups);
+                    $groups = array_merge($groups, $generalGroups);
                 }
             }
 
@@ -485,19 +485,20 @@ class Study
     }
 
     /**
-     * @param  int $phase
+     * @param  int   $phase
      * @param  array $moduleGroups
      * @return array
      */
-    private function getGeneralMandatoryGroups($phase, $moduleGroups) {
+    private function getGeneralMandatoryGroups($phase, $moduleGroups)
+    {
         $groups = array();
 
         //for each child node in the same phase check if branch is fully mandatory
-        foreach($moduleGroups as $group) {
-            if($phase == $group->getPhase() && count($group->getChildren()) == 0) {
+        foreach ($moduleGroups as $group) {
+            if ($phase == $group->getPhase() && count($group->getChildren()) == 0) {
                 if ($this->isFullMandatoryBranch($group)) {
                     $groups[] = $group;
-                } else {
+                }
             }
         }
 
@@ -508,18 +509,19 @@ class Study
      * @param  moduleGroup $group
      * @return boolean
      */
-    private function isFullMandatoryBranch($group) {
+    private function isFullMandatoryBranch($group)
+    {
         $result = false;
-        if($group->isMandatory()){
+        if ($group->isMandatory()) {
             if (null !== $group->getParent()) {
                 $result = $this->isFullMandatoryBranch($group->getParent());
             } else {
                 return true;
             }
         }
+
         return $result;
     }
-
 
     /**
      * @return EntityManager


### PR DESCRIPTION
Cache the application config.

**What's this about?**

ZF2 loads the configuration for every request. That means interpreting over 125 PHP files, executing them and merging the resulting arrays into one. ZF2 can cache the resulting mega-array, skipping the entire load/merge process.

**What's the catch?**

To allow for caching of the configuration, the configuration _mustn't_ contain anything other than arrays and primitives (strings, booleans, numbers). Functions are not allowed. This means all functions in our configuration had to be rewritten into factory classes.

This is not suited for development, and the cached configuration should explicitly be cleared in any deploy process.

**Is it useful?**

To test this, I removed the `->run()` part of `public/index.html` and ran `ab -n 200 -a 10 http://localhost:54887/`.

without caching:

```
This is ApacheBench, Version 2.3 <$Revision: 1638069 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking 127.0.0.1 (be patient)
Completed 100 requests
Completed 200 requests
Finished 200 requests


Server Software:        nginx/1.4.6
Server Hostname:        127.0.0.1
Server Port:            54887

Document Path:          /
Document Length:        16 bytes

Concurrency Level:      10
Time taken for tests:   22.498 seconds
Complete requests:      200
Failed requests:        19
   (Connect: 0, Receive: 0, Length: 19, Exceptions: 0)
Total transferred:      29178 bytes
HTML transferred:       3178 bytes
Requests per second:    8.89 [#/sec] (mean)
Time per request:       1124.905 [ms] (mean)
Time per request:       112.491 [ms] (mean, across all concurrent requests)
Transfer rate:          1.27 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:   145 1109 145.4   1102    1419
Waiting:      145 1108 145.4   1102    1419
Total:        146 1109 145.3   1102    1419

Percentage of the requests served within a certain time (ms)
  50%   1102
  66%   1128
  75%   1152
  80%   1193
  90%   1298
  95%   1333
  98%   1387
  99%   1418
 100%   1419 (longest request)
```

with caching:

```
This is ApacheBench, Version 2.3 <$Revision: 1638069 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking 127.0.0.1 (be patient)
Completed 100 requests
Completed 200 requests
Finished 200 requests


Server Software:        nginx/1.4.6
Server Hostname:        127.0.0.1
Server Port:            54887

Document Path:          /
Document Length:        16 bytes

Concurrency Level:      10
Time taken for tests:   18.249 seconds
Complete requests:      200
Failed requests:        19
   (Connect: 0, Receive: 0, Length: 19, Exceptions: 0)
Total transferred:      29179 bytes
HTML transferred:       3179 bytes
Requests per second:    10.96 [#/sec] (mean)
Time per request:       912.456 [ms] (mean)
Time per request:       91.246 [ms] (mean, across all concurrent requests)
Transfer rate:          1.56 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:   194  899  88.9    909    1139
Waiting:      194  899  88.9    909    1139
Total:        195  899  88.8    909    1139

Percentage of the requests served within a certain time (ms)
  50%    909
  66%    919
  75%    926
  80%    932
  90%    940
  95%    950
  98%    980
  99%   1083
 100%   1139 (longest request)
```
