### PR TITLE
Fix shift overlap bug: update logic to handle shifts starting and ending at the same time

### DIFF
--- a/module/ShiftBundle/Entity/RegistrationShift.php
+++ b/module/ShiftBundle/Entity/RegistrationShift.php
@@ -402,7 +402,7 @@ class RegistrationShift
                 return false;
             }
 
-            if ($this->getStartDate() < $shift->getEndDate() && $shift->getStartDate() < $this->getEndDate()) {
+            if ($this->getStartDate() < $shift->getEndDate() && $shift->getStartDate() < $this->getEndDate() || $this->getStartDate() === $shift->getStartDate()) {
                 return false;
             }
 

--- a/module/ShiftBundle/Entity/Shift.php
+++ b/module/ShiftBundle/Entity/Shift.php
@@ -493,7 +493,7 @@ class Shift
                 return false;
             }
 
-            if ($this->getStartDate() < $shift->getEndDate() && $shift->getStartDate() < $this->getEndDate()) {
+            if ($this->getStartDate() < $shift->getEndDate() && $shift->getStartDate() < $this->getEndDate() || $shift->getStartDate() === $this->getStartDate()) {
                 return false;
             }
         }


### PR DESCRIPTION
### Fix for Shift Overlap Bug: Identical Start and End Times Not Detected

#### Problem:
The current shift overlap detection logic fails to detect cases where two shifts start and end at the exact same time. This results in an incorrect outcome where such shifts are considered non-overlapping, even though they should be.

#### Solution:
This fix updates the logic to handle shifts that have identical start and end times. The new comparison ensures that shifts with matching start and end times are properly detected as overlapping.

Please review the changes and consider merging them to resolve the bug.