### PR TITLE
Fixed Double scan issue Cudi sale tool

### DIFF
--- a/module/CudiBundle/Resources/assets/sale/js/saleInterface.js
+++ b/module/CudiBundle/Resources/assets/sale/js/saleInterface.js
@@ -407,8 +407,6 @@
     }
 
     function _addArticle($this, id) {
-        console.log("_addArticle");
-
         var settings = $this.data('saleInterfaceSettings');
         $this.find('#article-' + id + ':not(.inactive)').each(function () {
             if ($(this).data('info').currentNumber < $(this).data('info').number) {
@@ -533,8 +531,6 @@
     }
 
     function _gotBarcode($this, barcode) {
-        console.log("_gotBarcode");
-
         var settings = $this.data('saleInterfaceSettings');
 
         var found = false;

--- a/module/CudiBundle/Resources/assets/sale/js/saleInterface.js
+++ b/module/CudiBundle/Resources/assets/sale/js/saleInterface.js
@@ -407,6 +407,8 @@
     }
 
     function _addArticle($this, id) {
+        console.log("_addArticle");
+
         var settings = $this.data('saleInterfaceSettings');
         $this.find('#article-' + id + ':not(.inactive)').each(function () {
             if ($(this).data('info').currentNumber < $(this).data('info').number) {
@@ -531,6 +533,8 @@
     }
 
     function _gotBarcode($this, barcode) {
+        console.log("_gotBarcode");
+
         var settings = $this.data('saleInterfaceSettings');
 
         var found = false;
@@ -543,6 +547,10 @@
                 found = true;
             }
 
+            if (found) {
+                return false;
+            }
+
             $($this.data('info').barcodes).each(function () {
                 if (_barcodeEquals(length, this, barcode)) {
                     $this.find('.addArticle').click();
@@ -550,9 +558,6 @@
                     return false;
                 }
             });
-
-            if (found)
-                return false;
         });
 
         if (found)


### PR DESCRIPTION
> **Test deze oplossing in een Incognito Tabblad!!!**  
> De js-code wordt ergens in de browser gecached dus wanneer je de sale tool open doet in een normaal tabblad nadat je iets hebt veranderd duurt het heel lang voordat deze aanpassingen worden weergegeven in de browser (bij mij was het pas aangepast de volgende dag!) (Cookies clearen helpt bij mij niet!) Beste is dus om gwn de sale tool open te doen in een incognito tabblad dan lijkt alles gwn te updaten zodra je de pagina herlaad

De code die wordt meegegeven aan de browser zit in "Litus/public/_assetic/sale_js.js" (dus niet in de CudiBundle) => Dit is een geminimaliseerde versie van verschillende sale tool scriptjes , momenteel is dit bestand **READ-ONLY** je moet dus best ook met chmod de lees en schrijf rechten van dit bestand aanpassen, anders worden je veranderingen in de andere scriptjes niet meegegeven aan de browser  
``sudo chmod 666 public/_assetic/sale_js.js``   
(standaard rechten zijn 644, voor moest je ze daarna willen terugbrengen naar hun originele staat)

Bij elke refresh van de browser wordt sale_js.js opnieuw gegenereerd vanuit de "bron scriptjes" wanneer je dus de schrijfrechten hebt aangepast kan je dus aanpassingen doen in de "bron scriptjes", je aanpassingen maken rechtstreeks in sale_js.js is dus nutteloos, want deze worden meteen overschreden wanneer sale_js.js opnieuw wordt gegenereerd

Het probleem zat em in saleInterface.js => _gotBarcode() => der is 2 keer dezelfde logica die de "add Article" knop zoekt en dan daarop klikt. waardoor er 2 keer een article wordt toegevoegd.

Op eerste zicht doen beide implementaties exact hetzelfde, maar ze doen het allebei op een ietsjes andere manier. ik gok dat dit is omdat één implementatie op zichzelf niet alle edge-cases vangt en het dus 2 keer wordt gedaan, maar ben niet een JS-expert dus kan het niet met zekerheid zeggen.  

Nu is het zo dat als de eerste methode de "add Article" knop vindt en erop klikt de 2de methode niet meer wordt uitgevoerd. Dan heb je nog steeds de 2de methode als "safety" in het geval van edge cases.